### PR TITLE
PLATUI-759: Exclude Heroku admin releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ sbt -Dheroku.apiToken=REPLACE_WITH_TOKEN "generateHerokuReport report.txt"
 This generates a tab-separated plain text file, report.txt, in the repository root directory that can
 be imported into a spreadsheet for manipulation.
 
+The usage report, by default, disregards automated releases made by the Heroku API maintenance user. This can be 
+changed or additional email addresses added to this exclude list by modifying the heroku.administratorEmails key
+in [application.conf](src/main/resources/application.conf)
+
 ## Spinning down Heroku prototypes
 
 To spin down multiple prototypes, create a plain text file, e.g. spin-down-list.txt,
@@ -99,4 +103,3 @@ prototype-2	prototype-2-prototype	FALSE
 ### License
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").
-    

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -18,4 +18,5 @@ heroku {
   readTimeoutMs = 10000
   connTimeoutMs = 50000
   apiToken = dummy-token
+  administratorEmails = ["api-maintenance@heroku.com"]
 }

--- a/src/main/scala/uk/gov/hmrc/initprototype/HerokuConfiguration.scala
+++ b/src/main/scala/uk/gov/hmrc/initprototype/HerokuConfiguration.scala
@@ -18,12 +18,14 @@ package uk.gov.hmrc.initprototype
 
 import com.typesafe.config.{Config, ConfigFactory}
 import scala.concurrent.duration.{Duration, MILLISECONDS}
+import scala.collection.JavaConverters._
 
 class HerokuConfiguration {
-  private val config: Config = ConfigFactory.load()
-  val baseUrl: String        = config.getString("heroku.baseUrl")
-  val apiToken: String       = config.getString("heroku.apiToken")
-  val timeout: Duration      = Duration(config.getInt("heroku.timeoutMs"), MILLISECONDS)
-  val connTimeoutMs: Int     = config.getInt("heroku.connTimeoutMs")
-  val readTimeoutMs: Int     = config.getInt("heroku.readTimeoutMs")
+  private val config: Config           = ConfigFactory.load()
+  val baseUrl: String                  = config.getString("heroku.baseUrl")
+  val apiToken: String                 = config.getString("heroku.apiToken")
+  val timeout: Duration                = Duration(config.getInt("heroku.timeoutMs"), MILLISECONDS)
+  val connTimeoutMs: Int               = config.getInt("heroku.connTimeoutMs")
+  val readTimeoutMs: Int               = config.getInt("heroku.readTimeoutMs")
+  val administratorEmails: Seq[String] = config.getStringList("heroku.administratorEmails").asScala
 }

--- a/src/main/scala/uk/gov/hmrc/initprototype/HerokuRelease.scala
+++ b/src/main/scala/uk/gov/hmrc/initprototype/HerokuRelease.scala
@@ -18,11 +18,12 @@ package uk.gov.hmrc.initprototype
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
-case class HerokuRelease(createdAt: String, description: String)
+case class HerokuRelease(createdAt: String, description: String, email: String = "")
 
 object HerokuRelease {
   implicit val herokuReleaseReads: Reads[HerokuRelease] = (
     (JsPath \ "created_at").read[String] and
-      (JsPath \ "description").read[String]
+      (JsPath \ "description").read[String] and
+      (JsPath \ "user" \ "email").read[String]
   )(HerokuRelease.apply _)
 }

--- a/src/main/scala/uk/gov/hmrc/initprototype/HerokuRelease.scala
+++ b/src/main/scala/uk/gov/hmrc/initprototype/HerokuRelease.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.initprototype
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
-case class HerokuRelease(createdAt: String, description: String, email: String = "")
+case class HerokuRelease(createdAt: String, description: String, email: String)
 
 object HerokuRelease {
   implicit val herokuReleaseReads: Reads[HerokuRelease] = (

--- a/src/test/resources/__files/body-apps-any-app-releases-hkzcT.json
+++ b/src/test/resources/__files/body-apps-any-app-releases-hkzcT.json
@@ -30,5 +30,21 @@
     "version": 202,
     "current": false,
     "output_stream_url": null
+  },
+  {
+    "addon_plan_names": [],
+    "app": {
+      "name": "any-app"
+    },
+    "created_at": "2020-09-17T20:14:38Z",
+    "description": "Enable allow-multiple-sni-endpoints feature",
+    "status": "succeeded",
+    "updated_at": "2020-09-17T20:14:38Z",
+    "user": {
+      "email": "api-maintenance@heroku.com"
+    },
+    "version": 40,
+    "current": false,
+    "output_stream_url": null
   }
 ]

--- a/src/test/scala/uk/gov/hmrc/initprototype/HerokuManagerSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/initprototype/HerokuManagerSpec.scala
@@ -186,9 +186,9 @@ class HerokuManagerSpec
       it("should get all the releases for the given app") {
         val (releases, _) = await(herokuManager.getAppReleases("any-app", range = None), 10 second)
 
-        releases.size             should be(4)
+        releases.size             should be(5)
         releases.head.description should equal("Initial release")
-        releases(3).description   should equal("Fourth release")
+        releases(4).description   should equal("Enable allow-multiple-sni-endpoints feature")
       }
     }
 

--- a/src/test/scala/uk/gov/hmrc/initprototype/HerokuReportSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/initprototype/HerokuReportSpec.scala
@@ -36,12 +36,12 @@ class HerokuReportSpec extends AnyFunSpec with Matchers with MockitoSugar with A
       .thenReturn(Future.successful(Seq("my-other-app", "my-test-app")))
     when(mockManager.getAppReleases("my-other-app", range = None))
       .thenReturn(Future.successful(
-        (Seq(HerokuRelease("2019-12-01", "First release"), HerokuRelease("2019-12-02", "Second release")), None)))
+        (Seq(HerokuRelease("2019-12-01", "First release", "gerald@example.com"), HerokuRelease("2019-12-02", "Second release", "john@example.com")), None)))
     when(mockManager.getAppReleases("my-test-app", range = None))
       .thenReturn(Future.successful(
         (Seq(
-          HerokuRelease("2019-12-03", "First release"),
-          HerokuRelease("2019-12-04", "Second release")
+          HerokuRelease("2019-12-03", "First release", "gerald@example.com"),
+          HerokuRelease("2019-12-04", "Second release", "john@example.com")
         ), None)))
     when(mockManager.getAppFormation("my-other-app"))
       .thenReturn(Future.successful(Some(HerokuFormation("Standard-1X", 1, HerokuApp("my-other-app")))))
@@ -71,8 +71,8 @@ class HerokuReportSpec extends AnyFunSpec with Matchers with MockitoSugar with A
         when(mockManager.getAppReleases("my-test-app", range = None))
           .thenReturn(Future.successful(
             (Seq(
-              HerokuRelease("2019-12-03", "First release"),
-              HerokuRelease("2019-12-04", "Second release"),
+              HerokuRelease("2019-12-03", "First release", "gerald@example.com"),
+              HerokuRelease("2019-12-04", "Second release", "john@example.com"),
               HerokuRelease("2020-02-01", "Admin release", "admin@example.com")
             ), None)))
 


### PR DESCRIPTION
Excludes automated releases so the Heroku usage report gives a clear picture of activity by real users.