### PR TITLE
PLATUI-1561 use heroku cli to discover auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ prototyping environment on Heroku.
 To use the Heroku build tasks, you will need:
 * a Heroku account linked to your HMRC email address
 * be a member and have admin access to the HMRC team
-* a Heroku API Key generated on the [Heroku 'Manage Account' settings page](https://dashboard.heroku.com/account)
+* have the heroku cli installed locally, or have a Heroku API Key generated from the [Heroku 'Manage Account' settings page](https://dashboard.heroku.com/account)
 
 ## Github prerequisites
 
@@ -26,7 +26,7 @@ in Heroku. The report lists the prototypes, their sizes, when they were first cr
 To run this task, having cloned the repository and changed to the repository root directory,
 
 ```shell script
-sbt -Dheroku.apiToken=REPLACE_WITH_HEROKU_API_KEY "generateHerokuReport report.txt"
+sbt "generateHerokuReport report.txt"
 ```
 
 This generates a tab-separated plain text file, report.txt, in the repository root directory that can
@@ -50,7 +50,7 @@ prototype-three
 Save this file into the root directory of this repository. Then run:
 
 ```shell script
-sbt -Dheroku.apiToken=REPLACE_WITH_HEROKU_API_KEY "spinDownHerokuApps spin-down-list.txt"
+sbt "spinDownHerokuApps spin-down-list.txt"
 ```
 
 You should get a report similar to:
@@ -125,7 +125,7 @@ The sbt task `generatePackageLockReport` can produce a report of which Github re
 The output will be saved to `package-lock-analysis.tsv`.
 
 ```shell script
-sbt -Dheroku.apiToken=REPLACE_WITH_HEROKU_API_KEY -Dheroku.apiToken=REPLACE_WITH_GITHUB_PERSONAL_ACCESS_TOKEN "generateHerokuReport report.txt"
+sbt -Dgithub.apiToken=REPLACE_WITH_GITHUB_PERSONAL_ACCESS_TOKEN "generateHerokuReport report.txt"
 sbt generatePackageLockReport
 ```
 

--- a/src/main/scala/uk/gov/hmrc/initprototype/HerokuAuthToken.scala
+++ b/src/main/scala/uk/gov/hmrc/initprototype/HerokuAuthToken.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.initprototype
+
+import scala.sys.process._
+import scala.util.{Failure, Success, Try}
+
+object HerokuAuthToken {
+  val logger                 = com.typesafe.scalalogging.Logger(this.getClass)
+  val loggingHerokuCliErrors = ProcessLogger(err => logger.error(s"[heroku cli] $err"))
+
+  def fromHerokuCli: String = Try(
+    "heroku auth:token".!!(loggingHerokuCliErrors)
+  ) match {
+    case Failure(_)        =>
+      throw new RuntimeException(
+        "Could not fetch auth token from heroku cli, run `heroku login` and retry, or provide token yourself via -Dheroku.apiToken="
+      )
+    case Success(apiToken) => apiToken.trim
+  }
+}

--- a/src/main/scala/uk/gov/hmrc/initprototype/HerokuConfiguration.scala
+++ b/src/main/scala/uk/gov/hmrc/initprototype/HerokuConfiguration.scala
@@ -23,7 +23,11 @@ import scala.collection.JavaConverters._
 class HerokuConfiguration {
   private val config: Config           = ConfigFactory.load()
   val baseUrl: String                  = config.getString("heroku.baseUrl")
-  val apiToken: String                 = config.getString("heroku.apiToken")
+  val apiToken: String                 = if (config.hasPath("heroku.apiToken")) {
+    config.getString("heroku.apiToken")
+  } else {
+    HerokuAuthToken.fromHerokuCli
+  }
   val jobTimeout: Duration             = Duration(config.getInt("heroku.jobTimeoutMs"), MILLISECONDS)
   val connTimeoutMs: Int               = config.getInt("heroku.connTimeoutMs")
   val readTimeoutMs: Int               = config.getInt("heroku.readTimeoutMs")

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -12,18 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-heroku {
-  baseUrl = "https://api.heroku.com"
-  jobTimeoutMs = 120000
-  readTimeoutMs = 10000
-  connTimeoutMs = 50000
-  administratorEmails = ["api-maintenance@heroku.com"]
-  defaultReportFile = "report.txt"
-}
-
-github {
-  baseUrl = "https://api.github.com"
-  readTimeoutMs = 10000
-  connTimeoutMs = 50000
-  packageLockReportFile = "package-lock-analysis.tsv"
-}
+heroku.apiToken = dummy-token
+github.apiToken = dummy-token


### PR DESCRIPTION
lets us avoid having to generate and maintain auth tokens manually if we
have the heroku cli installed and have run heroku login.